### PR TITLE
Added JSON dumping option

### DIFF
--- a/Sources/PT.PM.Cli.Common/CliParameters.cs
+++ b/Sources/PT.PM.Cli.Common/CliParameters.cs
@@ -71,8 +71,8 @@ namespace PT.PM.Cli.Common
         [Option('d', "dump", HelpText = "Stages to be dumped (ParseTree, Ust)", Separator = ',')]
         public IEnumerable<string> DumpStages { get; set; }
 
-        [Option('j', "json-output", HelpText = "Serialize results into json format")]
-        public string JsonOutputDir { get; set; }
+        [Option('j', "json-output", HelpText = "Serialize and dump results into json")]
+        public bool? JsonOutputFileName { get; set; }
 
         [Option('r', "render", HelpText = "Stages to be rendered", Separator = ',')]
         public IEnumerable<string> RenderStages { get; set; }

--- a/Sources/PT.PM.Cli.Common/CliParameters.cs
+++ b/Sources/PT.PM.Cli.Common/CliParameters.cs
@@ -71,6 +71,9 @@ namespace PT.PM.Cli.Common
         [Option('d', "dump", HelpText = "Stages to be dumped (ParseTree, Ust)", Separator = ',')]
         public IEnumerable<string> DumpStages { get; set; }
 
+        [Option('j', "json-output", HelpText = "Serialize results into json format")]
+        public string JsonOutputDir { get; set; }
+
         [Option('r', "render", HelpText = "Stages to be rendered", Separator = ',')]
         public IEnumerable<string> RenderStages { get; set; }
 

--- a/Sources/PT.PM.Cli.Common/CliParameters.cs
+++ b/Sources/PT.PM.Cli.Common/CliParameters.cs
@@ -72,7 +72,7 @@ namespace PT.PM.Cli.Common
         public IEnumerable<string> DumpStages { get; set; }
 
         [Option('j', "json-output", HelpText = "Serialize and dump results into json")]
-        public bool? JsonOutputFileName { get; set; }
+        public bool? IsDumpJsonOutput { get; set; }
 
         [Option('r', "render", HelpText = "Stages to be rendered", Separator = ',')]
         public IEnumerable<string> RenderStages { get; set; }

--- a/Sources/PT.PM.Cli.Common/CliProcessorBase.cs
+++ b/Sources/PT.PM.Cli.Common/CliProcessorBase.cs
@@ -176,9 +176,9 @@ namespace PT.PM.Cli.Common
             {
                 workflow.NotStrictJson = parameters.NotStrictJson.Value;
             }
-            if (parameters.JsonOutputDir != null)
+            if (parameters.JsonOutputFileName.HasValue)
             {
-                workflow.DumpJsonOutputDir = NormalizeLogsDir(parameters.JsonOutputDir);
+                workflow.IsDumpJsonOutputDir = parameters.JsonOutputFileName.Value;
             }
             if (parameters.StartStage != null)
             {

--- a/Sources/PT.PM.Cli.Common/CliProcessorBase.cs
+++ b/Sources/PT.PM.Cli.Common/CliProcessorBase.cs
@@ -176,6 +176,10 @@ namespace PT.PM.Cli.Common
             {
                 workflow.NotStrictJson = parameters.NotStrictJson.Value;
             }
+            if (parameters.JsonOutputDir != null)
+            {
+                workflow.DumpJsonOutputDir = NormalizeLogsDir(parameters.JsonOutputDir);
+            }
             if (parameters.StartStage != null)
             {
                 workflow.StartStage = parameters.StartStage.ParseEnum(ContinueWithInvalidArgs, workflow.StartStage, Logger);

--- a/Sources/PT.PM.Cli.Common/CliProcessorBase.cs
+++ b/Sources/PT.PM.Cli.Common/CliProcessorBase.cs
@@ -176,9 +176,9 @@ namespace PT.PM.Cli.Common
             {
                 workflow.NotStrictJson = parameters.NotStrictJson.Value;
             }
-            if (parameters.JsonOutputFileName.HasValue)
+            if (parameters.IsDumpJsonOutput.HasValue)
             {
-                workflow.IsDumpJsonOutputDir = parameters.JsonOutputFileName.Value;
+                workflow.IsDumpJsonOutput = parameters.IsDumpJsonOutput.Value;
             }
             if (parameters.StartStage != null)
             {

--- a/Sources/PT.PM/Workflow.cs
+++ b/Sources/PT.PM/Workflow.cs
@@ -99,6 +99,7 @@ namespace PT.PM
                 AntlrParser.ClearCacheIfRequired();
             }
 
+            DumpJsonOutput(result);
             result.ErrorCount = logger?.ErrorCount ?? 0;
             return result;
         }

--- a/Sources/PT.PM/WorkflowBase.cs
+++ b/Sources/PT.PM/WorkflowBase.cs
@@ -1,4 +1,5 @@
-﻿using PT.PM.AntlrUtils;
+﻿using Newtonsoft.Json;
+using PT.PM.AntlrUtils;
 using PT.PM.Common;
 using PT.PM.Common.CodeRepository;
 using PT.PM.Common.Exceptions;
@@ -40,6 +41,8 @@ namespace PT.PM
         public IPatternConverter<TPattern> PatternConverter { get; set; }
 
         public LanguageDetector LanguageDetector { get; set; } = new ParserLanguageDetector();
+
+        public string DumpJsonOutputDir { get; set; } = null; 
 
         public bool IsIncludeIntermediateResult { get; set; }
 
@@ -104,7 +107,7 @@ namespace PT.PM
         public bool LinearTextSpans { get; set; } = false;
 
         public bool NotStrictJson { get; set; } = false;
-
+ 
         public string LogsDir { get; set; } = "";
 
         public string DumpDir { get; set; } = "";
@@ -281,6 +284,22 @@ namespace PT.PM
                 string name = string.IsNullOrEmpty(result.SourceCodeFile.Name) ? "" : result.SourceCodeFile.Name + ".";
                 Directory.CreateDirectory(DumpDir);
                 File.WriteAllText(Path.Combine(DumpDir, name + ParseTreeDumper.UstSuffix), json);
+            }
+        }
+
+        protected void DumpJsonOutput(TWorkflowResult workflow)
+        {
+            if (DumpJsonOutputDir == null)
+            {
+                return;
+            }
+            else
+            {
+                string json = JsonConvert.SerializeObject(workflow, Formatting.Indented, LanguageJsonConverter.Instance);
+                var res = Directory.CreateDirectory(DumpJsonOutputDir);
+                string name = "Result.json";
+                File.WriteAllText(Path.Combine(DumpJsonOutputDir, name), json);
+                var f = File.OpenText(Path.Combine(DumpJsonOutputDir, name));
             }
         }
 

--- a/Sources/PT.PM/WorkflowBase.cs
+++ b/Sources/PT.PM/WorkflowBase.cs
@@ -42,7 +42,7 @@ namespace PT.PM
 
         public LanguageDetector LanguageDetector { get; set; } = new ParserLanguageDetector();
 
-        public string DumpJsonOutputDir { get; set; } = null; 
+        public bool IsDumpJsonOutputDir { get; set; } = false; 
 
         public bool IsIncludeIntermediateResult { get; set; }
 
@@ -289,17 +289,11 @@ namespace PT.PM
 
         protected void DumpJsonOutput(TWorkflowResult workflow)
         {
-            if (DumpJsonOutputDir == null)
-            {
-                return;
-            }
-            else
+            if (IsDumpJsonOutputDir)
             {
                 string json = JsonConvert.SerializeObject(workflow, Formatting.Indented, LanguageJsonConverter.Instance);
-                var res = Directory.CreateDirectory(DumpJsonOutputDir);
-                string name = "Result.json";
-                File.WriteAllText(Path.Combine(DumpJsonOutputDir, name), json);
-                var f = File.OpenText(Path.Combine(DumpJsonOutputDir, name));
+                Directory.CreateDirectory(DumpDir);
+                File.WriteAllText(Path.Combine(DumpDir, "output.json"), json);
             }
         }
 

--- a/Sources/PT.PM/WorkflowBase.cs
+++ b/Sources/PT.PM/WorkflowBase.cs
@@ -42,7 +42,7 @@ namespace PT.PM
 
         public LanguageDetector LanguageDetector { get; set; } = new ParserLanguageDetector();
 
-        public bool IsDumpJsonOutputDir { get; set; } = false; 
+        public bool IsDumpJsonOutput { get; set; } = false; 
 
         public bool IsIncludeIntermediateResult { get; set; }
 
@@ -289,7 +289,7 @@ namespace PT.PM
 
         protected void DumpJsonOutput(TWorkflowResult workflow)
         {
-            if (IsDumpJsonOutputDir)
+            if (IsDumpJsonOutput)
             {
                 string json = JsonConvert.SerializeObject(workflow, Formatting.Indented, LanguageJsonConverter.Instance);
                 Directory.CreateDirectory(DumpDir);

--- a/Sources/PT.PM/WorkflowResultBase.cs
+++ b/Sources/PT.PM/WorkflowResultBase.cs
@@ -1,4 +1,6 @@
-﻿using PT.PM.Common;
+﻿using Newtonsoft.Json;
+using PT.PM.Common;
+using PT.PM.Common.Json;
 using PT.PM.Common.Nodes;
 using PT.PM.Matching;
 using System;
@@ -58,10 +60,13 @@ namespace PT.PM
 
         public int ErrorCount { get; set; }
 
+        [JsonIgnore]
         public HashSet<CodeFile> SourceCodeFiles => sourceCodeFiles;
 
+        [JsonIgnore]
         public IReadOnlyList<ParseTree> ParseTrees => ValidateStageAndReturn(PM.Stage.ParseTree.ToString(), parseTrees);
 
+        [JsonIgnore]
         public IReadOnlyList<RootUst> Usts
         {
             get
@@ -75,8 +80,10 @@ namespace PT.PM
             }
         }
 
+        [JsonIgnore]
         public IReadOnlyList<IMatchResultBase> MatchResults => ValidateStageAndReturn(PM.Stage.Match.ToString(), matchResults);
 
+        [JsonIgnore]
         public IReadOnlyList<TPattern> Patterns
         {
             get

--- a/Sources/PT.PM/WorkflowResultBase.cs
+++ b/Sources/PT.PM/WorkflowResultBase.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using PT.PM.Common;
-using PT.PM.Common.Json;
 using PT.PM.Common.Nodes;
 using PT.PM.Matching;
 using System;
@@ -81,7 +80,7 @@ namespace PT.PM
         }
 
         [JsonIgnore]
-        public IReadOnlyList<IMatchResultBase> MatchResults => ValidateStageAndReturn(PM.Stage.Match.ToString(), matchResults);
+        public IReadOnlyList<IMatchResultBase> MatchResults => matchResults;
 
         [JsonIgnore]
         public IReadOnlyList<TPattern> Patterns
@@ -105,6 +104,7 @@ namespace PT.PM
         public long TotalPatternsTicks => totalPatternsTicks;
 
         public long TotalLexerTicks => totalLexerTicks;
+        public int TotalMatchesCount => MatchResults.Count;
         public long TotalParserTicks => totalParserTicks;
 
         public int TotalProcessedFilesCount => totalProcessedFilesCount;
@@ -134,6 +134,7 @@ namespace PT.PM
         public void AddResultEntity(RootUst ust, bool convert)
         {
             if (IsIncludeIntermediateResult || (convert && Stage.Is(PM.Stage.Ust)) || (!convert && Stage.Is(PM.Stage.SimplifiedUst)) ||
+                Stage.Is(PM.Stage.Match) ||
                 RenderStages.Any(stage => Convert.ToInt32(stage) == (int)PM.Stage.Ust))
             {
                 int ustIndex = usts.FindIndex(tree => tree.SourceCodeFile == ust.SourceCodeFile);


### PR DESCRIPTION
Implemented `--json-output` (shortly `-j`) bool option for results dumping in JSON format, file saves in the `DumpDir`.