### PR TITLE
PatternAny by target source code and ust string

### DIFF
--- a/Sources/PT.PM.CSharpParseTreeUst.Tests/CSharpConverterTests.cs
+++ b/Sources/PT.PM.CSharpParseTreeUst.Tests/CSharpConverterTests.cs
@@ -23,7 +23,7 @@ namespace PT.PM.CSharpParseTreeUst.Tests
             string fileName = Path.Combine(TestUtility.GrammarsDirectory, "csharp", "not-ready-examples", "AllInOne.cs");
             var workflowResults = TestUtility.CheckFile(fileName, Stage.Ust);
             var ust = workflowResults.Usts.First();
-            bool result = ust.AnyDescendant(descendant =>
+            bool result = ust.AnyDescendantOrSelf(descendant =>
             {
                 return descendant is TypeDeclaration typeDeclaration &&
                        typeDeclaration.BaseTypes.Any(type => type.TypeText == nameof(IDisposable));

--- a/Sources/PT.PM.CSharpParseTreeUst/AspxConverter.cs
+++ b/Sources/PT.PM.CSharpParseTreeUst/AspxConverter.cs
@@ -164,7 +164,7 @@ namespace PT.PM.CSharpParseTreeUst
             SyntaxTree tree = CSharpSyntaxTree.ParseText(code, new CSharpParseOptions(kind: SourceCodeKind.Script));
             var converter = new CSharpRoslynParseTreeConverter();
             RootUst result = converter.Convert(new CSharpRoslynParseTree(tree) { SourceCodeFile = sourceCodeFile });
-            result.ApplyActionToDescendants(ust => ust.TextSpan = ust.TextSpan.AddOffset(location.Start));
+            result.ApplyActionToDescendantsAndSelf(ust => ust.TextSpan = ust.TextSpan.AddOffset(location.Start));
             return result;
         }
 
@@ -174,9 +174,9 @@ namespace PT.PM.CSharpParseTreeUst
             var converter = new CSharpRoslynParseTreeConverter();
             Ust result = converter.Visit(node);
             RootUst resultRoot =
-                result as RootUst ?? new RootUst(sourceCodeFile, CSharp.Language) { Node = result };
+                result as RootUst ?? new RootUst(sourceCodeFile, CSharp.Language) { Node = result, TextSpan = result.TextSpan };
             resultRoot.SourceCodeFile = sourceCodeFile;
-            result.ApplyActionToDescendants(ust => ust.TextSpan = ust.TextSpan.AddOffset(offset));
+            result.ApplyActionToDescendantsAndSelf(ust => ust.TextSpan = ust.TextSpan.AddOffset(offset));
             return result;
         }
 

--- a/Sources/PT.PM.CSharpParseTreeUst/Converter/CSharpRoslynParseTreeConverter.cs
+++ b/Sources/PT.PM.CSharpParseTreeUst/Converter/CSharpRoslynParseTreeConverter.cs
@@ -87,7 +87,10 @@ namespace PT.PM.CSharpParseTreeUst.RoslynUstVisitor
 
             if (root == null)
             {
-                root = new RootUst(children.FirstOrDefault()?.Root?.SourceCodeFile, CSharp.Language);
+                root = new RootUst(null, CSharp.Language)
+                {
+                    TextSpan = node.GetTextSpan()
+                };
             }
             root.Nodes = children.ToArray();
             return root;

--- a/Sources/PT.PM.Common/CodeFile.cs
+++ b/Sources/PT.PM.Common/CodeFile.cs
@@ -120,6 +120,11 @@ namespace PT.PM.Common
 
         public bool IsEmpty => string.IsNullOrEmpty(FullName) && string.IsNullOrEmpty(Code);
 
+        public string GetSubstring(TextSpan textSpan)
+        {
+            return Code.Substring(textSpan.Start, textSpan.Length);
+        }
+
         private void InitLineIndexesIfRequired()
         {
             if (lineIndexes == null)

--- a/Sources/PT.PM.Common/Json/TextSpanJsonConverter.cs
+++ b/Sources/PT.PM.Common/Json/TextSpanJsonConverter.cs
@@ -49,7 +49,7 @@ namespace PT.PM.Common.Json
                     }
                     else
                     {
-                        CodeFile codeFile = textSpan.CodeFile ?? CurrentCodeFile;
+                        CodeFile codeFile = textSpan.GetCodeFile(CurrentCodeFile);
                         if (codeFile != null)
                         {
                             textSpanString = codeFile.GetLineColumnTextSpan(textSpan).ToString(includeFileName);

--- a/Sources/PT.PM.Common/Json/UstJsonConverterReader.cs
+++ b/Sources/PT.PM.Common/Json/UstJsonConverterReader.cs
@@ -58,7 +58,7 @@ namespace PT.PM.Common.Json
                     ? languageString.ParseLanguages().FirstOrDefault()
                     : Uncertain.Language;
 
-                rootUst = (RootUst)Activator.CreateInstance(type, null, language);
+                rootUst = new RootUst(null, language);
                 ProcessRootUst(rootUst);
 
                 ust = rootUst;
@@ -83,7 +83,16 @@ namespace PT.PM.Common.Json
             }
             ancestors.Push(ust);
 
-            List <TextSpan> textSpans =
+            try
+            {
+                serializer.Populate(jObject.CreateReader(), ust);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(JsonFile, jObject, ex);
+            }
+
+            List<TextSpan> textSpans =
                 jObject[nameof(Ust.TextSpan)]?.ToTextSpans(serializer).ToList() ?? null;
 
             if (textSpans != null && textSpans.Count > 0)
@@ -97,15 +106,6 @@ namespace PT.PM.Common.Json
                     ust.InitialTextSpans = textSpans;
                     ust.TextSpan = textSpans.First();
                 }
-            }
-
-            try
-            {
-                serializer.Populate(jObject.CreateReader(), ust);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(JsonFile, jObject, ex);
             }
 
             if (!IgnoreExtraProcess)

--- a/Sources/PT.PM.Common/Nodes/RootUst.cs
+++ b/Sources/PT.PM.Common/Nodes/RootUst.cs
@@ -30,6 +30,7 @@ namespace PT.PM.Common.Nodes
         {
             SourceCodeFile = sourceCodeFile ?? CodeFile.Empty;
             Language = language;
+            TextSpan = new TextSpan(0, SourceCodeFile.Code.Length);
         }
 
         public override Ust[] GetChildren()
@@ -48,7 +49,7 @@ namespace PT.PM.Common.Nodes
         private Language[] GetSublangauges()
         {
             var result = new HashSet<Language>();
-            var descendants = this.WhereDescendants(child => child is RootUst)
+            var descendants = this.WhereDescendantsOrSelf(child => child is RootUst)
                 .Cast<RootUst>();
             foreach (RootUst descendant in descendants)
             {

--- a/Sources/PT.PM.Common/Nodes/Ust.cs
+++ b/Sources/PT.PM.Common/Nodes/Ust.cs
@@ -25,7 +25,11 @@ namespace PT.PM.Common.Nodes
 
         public virtual bool IsTerminal => false;
 
-        public LineColumnTextSpan LineColumnTextSpan => Root?.SourceCodeFile?.GetLineColumnTextSpan(TextSpan);
+        public LineColumnTextSpan LineColumnTextSpan => CurrentCodeFile?.GetLineColumnTextSpan(TextSpan);
+
+        public CodeFile CurrentCodeFile => this is RootUst rootUst ? rootUst.SourceCodeFile : Root?.SourceCodeFile;
+
+        public RootUst RootOrThis => this is RootUst rootUst ? rootUst : Root;
 
         [JsonIgnore]
         public TextSpan TextSpan { get; set; }

--- a/Sources/PT.PM.Common/Nodes/UstLinq.cs
+++ b/Sources/PT.PM.Common/Nodes/UstLinq.cs
@@ -6,42 +6,45 @@ namespace PT.PM.Common
 {
     public static class UstLinq
     {
-        public static void ApplyActionToDescendants(this Ust ust, Action<Ust> action)
+        public static void ApplyActionToDescendantsAndSelf(this Ust ust, Action<Ust> action)
         {
-            foreach (var child in ust.Children)
+            action(ust);
+
+            foreach (Ust child in ust.Children)
             {
                 if (child != null)
                 {
-                    action(child);
-                    child.ApplyActionToDescendants(action);
+                    child.ApplyActionToDescendantsAndSelf(action);
                 }
             }
         }
 
-        public static bool AnyDescendant(this Ust ust, Func<Ust, bool> predicate)
+        public static bool AnyDescendantOrSelf(this Ust ust, Func<Ust, bool> predicate)
         {
             if (predicate(ust))
             {
                 return true;
             }
-            foreach (var child in ust.Children)
+
+            foreach (Ust child in ust.Children)
             {
-                if (child != null && child.AnyDescendant(predicate))
+                if (child != null && child.AnyDescendantOrSelf(predicate))
                 {
                     return true;
                 }
             }
+
             return false;
         }
 
-        public static List<Ust> Descendants(this Ust ust) => ust.WhereDescendants();
+        public static List<Ust> DescendantsAndSelf(this Ust ust) => ust.WhereDescendantsOrSelf();
 
-        public static List<Ust> WhereDescendants(this Ust ust, Func<Ust, bool> predicate = null)
+        public static List<Ust> WhereDescendantsOrSelf(this Ust ust, Func<Ust, bool> predicate = null)
         {
             var result = new List<Ust>();
-            GetDescendants(ust);
+            GetDescendantsAndSelf(ust);
 
-            void GetDescendants(Ust localResult)
+            void GetDescendantsAndSelf(Ust localResult)
             {
                 if (localResult != null)
                 {
@@ -51,7 +54,7 @@ namespace PT.PM.Common
                     }
                     foreach (Ust child in localResult.Children)
                     {
-                        GetDescendants(child);
+                        GetDescendantsAndSelf(child);
                     }
                 }
             }

--- a/Sources/PT.PM.Common/Nodes/UstUtils.cs
+++ b/Sources/PT.PM.Common/Nodes/UstUtils.cs
@@ -154,7 +154,7 @@ namespace PT.PM.Common.Nodes
             }
             else
             {
-                result = ust.WhereDescendants(
+                result = ust.WhereDescendantsOrSelf(
                     node => node is RootUst rootUst && analyzedLanguages.Contains(rootUst.Language))
                     .Cast<RootUst>()
                     .ToArray();

--- a/Sources/PT.PM.JavaParseTreeUst.Tests/JavaConverterTests.cs
+++ b/Sources/PT.PM.JavaParseTreeUst.Tests/JavaConverterTests.cs
@@ -86,7 +86,7 @@ namespace PT.PM.JavaParseTreeUst.Tests
                     Initializers = data.Item1,
                     Sizes = data.Item2
                 };
-                bool exist = ust.AnyDescendant(node => node.Equals(arrayCreationExpression));
+                bool exist = ust.AnyDescendantOrSelf(node => node.Equals(arrayCreationExpression));
                 Assert.IsTrue(exist, "Test failed on " + i + " iteration.");
             }
         }
@@ -109,7 +109,7 @@ namespace PT.PM.JavaParseTreeUst.Tests
             var workflowResult = workflow.Process();
             var ust = workflowResult.Usts.First();
 
-            Assert.IsTrue(ust.AnyDescendant(ustNode =>
+            Assert.IsTrue(ust.AnyDescendantOrSelf(ustNode =>
                 ustNode is StringLiteral stringLiteral && stringLiteral.Text == "a"));
         }
 
@@ -119,7 +119,7 @@ namespace PT.PM.JavaParseTreeUst.Tests
             string fileName = Path.Combine(TestUtility.GrammarsDirectory, "java", "examples", "AllInOne7.java");
             var workflowResults = TestUtility.CheckFile(fileName, Stage.Ust);
             var ust = workflowResults.Usts.First();
-            bool result = ust.AnyDescendant(descendant =>
+            bool result = ust.AnyDescendantOrSelf(descendant =>
             {
                 return descendant is TypeDeclaration typeDeclaration &&
                        typeDeclaration.BaseTypes.Any(type => type.TypeText == "ActionListener");

--- a/Sources/PT.PM.Matching/PatternRoot.cs
+++ b/Sources/PT.PM.Matching/PatternRoot.cs
@@ -120,7 +120,7 @@ namespace PT.PM.Matching
                 }
 
                 var match = new MatchResult(
-                    ust is RootUst rootUst ? rootUst : ust.Root, context.PatternUst, context.Locations);
+                    ust.RootOrThis, context.PatternUst, context.Locations);
 
                 results.Add(match);
                 context.Logger.LogInfo(match);

--- a/Sources/PT.PM.Matching/Patterns/PatternAny.cs
+++ b/Sources/PT.PM.Matching/Patterns/PatternAny.cs
@@ -22,11 +22,13 @@ namespace PT.PM.Matching.Patterns
 
         public override bool Any => Regex == null || RegexString.Equals(Default);
 
+        public bool UseUstString { get; set; }
+
         public PatternAny()
         {
         }
 
-        public PatternAny(string regex, TextSpan textSpan = default(TextSpan))
+        public PatternAny(string regex, TextSpan textSpan = default)
             : base(textSpan)
         {
             RegexString = regex;
@@ -43,8 +45,18 @@ namespace PT.PM.Matching.Patterns
                 return context.AddMatch(ust);
             }
 
-            string ustString = ust.ToString();
-            var matches = Regex.MatchRegex(ustString, (ust as StringLiteral)?.EscapeCharsLength ?? 0);
+            string treeString;
+
+            if (UseUstString)
+            {
+                treeString = ust.ToString();
+            }
+            else
+            {
+                treeString = ust.CurrentCodeFile?.GetSubstring(ust.TextSpan) ?? "";
+            }
+
+            var matches = Regex.MatchRegex(treeString, (ust as StringLiteral)?.EscapeCharsLength ?? 0);
 
             if (ust.InitialTextSpans?.Any() ?? false)
             {

--- a/Sources/PT.PM.Matching/Patterns/PatternArbitraryDepth.cs
+++ b/Sources/PT.PM.Matching/Patterns/PatternArbitraryDepth.cs
@@ -29,7 +29,7 @@ namespace PT.PM.Matching.Patterns
 
         public override MatchContext Match(Ust ust, MatchContext context)
         {
-            var result = ust.AnyDescendant(ustNode => MatchExpression(ustNode, context).Success);
+            var result = ust.AnyDescendantOrSelf(ustNode => MatchExpression(ustNode, context).Success);
             return context.Set(result).AddUstIfSuccess(ust);
         }
 

--- a/Sources/PT.PM.Matching/Patterns/PatternStatements.cs
+++ b/Sources/PT.PM.Matching/Patterns/PatternStatements.cs
@@ -64,7 +64,7 @@ namespace PT.PM.Matching.Patterns
                         !(statement is WrapperStatement));
                 Expression[] expressions = statements.SelectMany(statement =>
                     statement
-                    .WhereDescendants(descendant =>
+                    .WhereDescendantsOrSelf(descendant =>
                         descendant is Expression expressionDescendant &&
                         !(expressionDescendant is Token)))
                     .Cast<Expression>()

--- a/Sources/PT.PM.PhpParseTreeUst.Tests/PhpParserTests.cs
+++ b/Sources/PT.PM.PhpParseTreeUst.Tests/PhpParserTests.cs
@@ -35,7 +35,7 @@ namespace PT.PM.PhpParseTreeUst.Tests
                 var converter = new PhpAntlrParseTreeConverter();
                 RootUst ust = converter.Convert(parseTree);
 
-                Ust intNode = ust.WhereDescendants(
+                Ust intNode = ust.WhereDescendantsOrSelf(
                     node => node is IntLiteral intLiteral && intLiteral.Value == 42).First();
 
                 LineColumnTextSpan intNodeSpan = intNode.LineColumnTextSpan;
@@ -43,7 +43,7 @@ namespace PT.PM.PhpParseTreeUst.Tests
                 Assert.AreEqual(12, intNodeSpan.BeginColumn);
                 Assert.AreEqual(14, intNodeSpan.EndColumn);
 
-                Ust heredocNode = ust.WhereDescendants(
+                Ust heredocNode = ust.WhereDescendantsOrSelf(
                     node => node is StringLiteral stringLiteral &&
                     stringLiteral.Text.StartsWith("Heredoc text")).First();
 
@@ -51,7 +51,7 @@ namespace PT.PM.PhpParseTreeUst.Tests
                 Assert.AreEqual(3, heredocNodeSpan.BeginLine);
                 Assert.AreEqual(6, heredocNodeSpan.EndLine);
 
-                Ust serverAddressNode = ust.WhereDescendants(
+                Ust serverAddressNode = ust.WhereDescendantsOrSelf(
                     node => node is StringLiteral stringLiteral &&
                     stringLiteral.Text.Contains("http://127.0.0.1")).First();
 

--- a/Sources/PT.PM.PhpParseTreeUst/PhpAntlrParseTreeConverter.cs
+++ b/Sources/PT.PM.PhpParseTreeUst/PhpAntlrParseTreeConverter.cs
@@ -145,7 +145,7 @@ namespace PT.PM.PhpParseTreeUst
             result.Root = root;
             result.Parent = root;
             int jsCodeOffset = Tokens[jsStartCodeInd].StartIndex;
-            result.ApplyActionToDescendants(ustNode => ustNode.TextSpan = ustNode.TextSpan.AddOffset(jsCodeOffset));
+            result.ApplyActionToDescendantsAndSelf(ustNode => ustNode.TextSpan = ustNode.TextSpan.AddOffset(jsCodeOffset));
             return result;
         }
 

--- a/Sources/PT.PM.Tests/UstPreprocessorTests.cs
+++ b/Sources/PT.PM.Tests/UstPreprocessorTests.cs
@@ -61,7 +61,7 @@ namespace PT.PM.Tests
             };
             var ust = workflow.Process().Usts.First();
 
-            Assert.IsTrue(ust.AnyDescendant(
+            Assert.IsTrue(ust.AnyDescendantOrSelf(
                 node => node is StringLiteral str && str.Text == "none"));
         }
 

--- a/Sources/PT.PM.Tests/UstVisitorTests.cs
+++ b/Sources/PT.PM.Tests/UstVisitorTests.cs
@@ -33,7 +33,7 @@ namespace PT.PM.Tests
             string fileName = Path.Combine(TestUtility.GrammarsDirectory, "csharp", "not-ready-examples", "AllInOne.cs");
             WorkflowResult result = TestUtility.CheckFile(fileName, Stage.Ust);
 
-            IEnumerable<Ust> descendantsExceptFirst = result.Usts.First().WhereDescendants().Skip(1);
+            IEnumerable<Ust> descendantsExceptFirst = result.Usts.First().WhereDescendantsOrSelf().Skip(1);
             foreach (var descendant in descendantsExceptFirst)
             {
                 if (!(descendant is RootUst))


### PR DESCRIPTION
* Correct RootUst text spans
* Match both by target source code and ust string, fixed #160 
* UstLinq: method names fixes (`Self` suffix)