### PR TITLE
Pattern array creation

### DIFF
--- a/Sources/PT.PM.Common/Nodes/Expressions/ArrayCreationExpression.cs
+++ b/Sources/PT.PM.Common/Nodes/Expressions/ArrayCreationExpression.cs
@@ -8,6 +8,8 @@ namespace PT.PM.Common.Nodes.Expressions
     {
         public TypeToken Type { get; set; }
 
+        public IdToken KeywordNew { get; set; }
+
         public List<Expression> Sizes { get; set; }
 
         public List<Expression> Initializers { get; set; }
@@ -63,6 +65,13 @@ namespace PT.PM.Common.Nodes.Expressions
             }
 
             var otherArrayCreation = (ArrayCreationExpression)other;
+
+            int compareKeywordNewResult = KeywordNew.CompareTo(otherArrayCreation.KeywordNew);
+            if (compareKeywordNewResult != 0)
+            {
+                return compareKeywordNewResult;
+            }
+
             int compareSizesResult = Sizes.CompareTo(otherArrayCreation.Sizes);
             if (compareSizesResult != 0)
             {

--- a/Sources/PT.PM.Matching/IPatternVisitor.cs
+++ b/Sources/PT.PM.Matching/IPatternVisitor.cs
@@ -8,6 +8,7 @@ namespace PT.PM.Matching
         T Visit(PatternAnd patternAnd);
         T Visit(PatternAny patternAny);
         T Visit(PatternArgs patternArgs);
+        T Visit(PatternArrayCreationExpression patternArrayCreationExpression);
         T Visit(PatternAssignmentExpression patternAssignmentExpression);
         T Visit(PatternThisReferenceToken patternThisReferenceToken);
         T Visit(PatternBaseReferenceToken patternBaseReferenceToken);

--- a/Sources/PT.PM.Matching/PatternVisitor.cs
+++ b/Sources/PT.PM.Matching/PatternVisitor.cs
@@ -44,6 +44,11 @@ namespace PT.PM.Matching
             return VisitChildren(patternArgs);
         }
 
+        public T Visit(PatternArrayCreationExpression patternArrayCreationExpression)
+        {
+            return VisitChildren(patternArrayCreationExpression);
+        }
+
         public virtual T Visit(PatternAssignmentExpression patternAssignmentExpression)
         {
             return VisitChildren(patternAssignmentExpression);

--- a/Sources/PT.PM.Matching/Patterns/PatternArrayCreationExpression.cs
+++ b/Sources/PT.PM.Matching/Patterns/PatternArrayCreationExpression.cs
@@ -10,6 +10,8 @@ namespace PT.PM.Matching.Patterns
     {
         public PatternUst Type { get; set; }
 
+        public bool StackAllocated { get; set; } = false;
+
         public List<PatternUst> Sizes { get; set; }
 
         public List<PatternUst> Initializers { get; set; }
@@ -33,6 +35,12 @@ namespace PT.PM.Matching.Patterns
         {
             var arrayCreationExpression = ust as ArrayCreationExpression;
             if (arrayCreationExpression == null)
+            {
+                return context.Fail();
+            }
+
+            // If we're looking for a stack allocated array there should be NO `new` keyword
+            if (StackAllocated && arrayCreationExpression.KeywordNew != null)
             {
                 return context.Fail();
             }

--- a/Sources/PT.PM.Matching/Patterns/PatternArrayCreationExpression.cs
+++ b/Sources/PT.PM.Matching/Patterns/PatternArrayCreationExpression.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using PT.PM.Common;
+using PT.PM.Common.Nodes;
+using PT.PM.Common.Nodes.Expressions;
+
+namespace PT.PM.Matching.Patterns
+{
+    public class PatternArrayCreationExpression : PatternUst, IPatternExpression
+    {
+        public PatternUst Type { get; set; }
+
+        public List<PatternUst> Sizes { get; set; }
+
+        public List<PatternUst> Initializers { get; set; }
+
+        public PatternArrayCreationExpression()
+        {
+            Type = new PatternAny();
+            Sizes = new List<PatternUst>();
+            Initializers = new List<PatternUst>();
+        }
+
+        public PatternArrayCreationExpression(PatternUst type, List<PatternUst> sizes, List<PatternUst> initializers,
+            TextSpan textSpan = default) : base(textSpan)
+        {
+            Type = type ?? throw new ArgumentNullException(nameof(type));
+            Sizes = sizes ?? throw new ArgumentNullException(nameof(sizes));
+            Initializers = initializers ?? throw new ArgumentNullException(nameof(initializers));
+        }
+
+        protected override MatchContext Match(Ust ust, MatchContext context)
+        {
+            var arrayCreationExpression = ust as ArrayCreationExpression;
+            if (arrayCreationExpression == null)
+            {
+                return context.Fail();
+            }
+
+            MatchContext newContext = Type.MatchUst(arrayCreationExpression.Type, context);
+            if (!newContext.Success)
+            {
+                return newContext;
+            }
+
+            if (Sizes.Count != arrayCreationExpression.Sizes.Count)
+            {
+                return context.Fail();
+            }
+            for (int i = 0; i < Sizes.Count; i++)
+            {
+                newContext = Sizes[i].MatchUst(arrayCreationExpression.Sizes[i], newContext);
+                if (!newContext.Success)
+                {
+                    return newContext;
+                }
+            }
+
+            if (Initializers.Count != arrayCreationExpression.Initializers.Count)
+            {
+                return context.Fail();
+            }
+            for (int i = 0; i < Initializers.Count; i++)
+            {
+                newContext = Initializers[i].MatchUst(arrayCreationExpression.Initializers[i], newContext);
+                if (!newContext.Success)
+                {
+                    return newContext;
+                }
+            }
+
+            return newContext.AddUstIfSuccess(arrayCreationExpression);
+        }
+
+        public PatternUst[] GetArgs()
+        {
+            var result = new List<PatternUst> { Type };
+            result.AddRange(Sizes);
+            result.AddRange(Initializers);
+
+            return result.ToArray();
+        }
+
+        public Type UstType => typeof(ArrayCreationExpression);
+    }
+}

--- a/Sources/PT.PM.Tests/UstVisitorTests.cs
+++ b/Sources/PT.PM.Tests/UstVisitorTests.cs
@@ -39,7 +39,7 @@ namespace PT.PM.Tests
                         var parameters = methodInfo.GetParameters();
                         return parameters.Length > 0 && parameters[0].ParameterType == type;
                     }) != null,
-                    $"Visitor for Type {type} is not exists");
+                    $"Visitor for Type {type} does not exist");
             }
         }
 


### PR DESCRIPTION
`public IdToken KeywordNew` was added to `ArrayCreationExpression` to distinguish between stack allocated and heap allocated arrays (needed for Clangs).

`PatternArrayCreationExpression` class was implemented.