### PR TITLE
Matching even without this keyword as long as it's optional.

### DIFF
--- a/Sources/PT.PM.Matching/Patterns/PatternMemberReferenceExpression.cs
+++ b/Sources/PT.PM.Matching/Patterns/PatternMemberReferenceExpression.cs
@@ -35,7 +35,14 @@ namespace PT.PM.Matching.Patterns
             MatchContext newContext = Target.MatchUst(memberRef.Target, context);
             if (!newContext.Success)
             {
-                return newContext;
+                // Ugly hack to handle optional `this`
+                if (Target is PatternMemberReferenceExpression patternMemberReference && patternMemberReference.Target is PatternThisReferenceToken)
+                {
+                    newContext = patternMemberReference.Name.MatchUst(memberRef.Target, context);
+                }
+
+                if (!newContext.Success)
+                    return newContext;
             }
 
             newContext = Name.MatchUst(memberRef.Name, newContext);


### PR DESCRIPTION
Special case inside `PatternMemberReferenceExpression.Match`.