### PR TITLE
Fix null ust processing

### DIFF
--- a/Sources/PT.PM.Common/Nodes/UstLinq.cs
+++ b/Sources/PT.PM.Common/Nodes/UstLinq.cs
@@ -8,6 +8,11 @@ namespace PT.PM.Common
     {
         public static void ApplyActionToDescendantsAndSelf(this Ust ust, Action<Ust> action)
         {
+            // The root might be null itself
+            if (ust == null)
+            {
+                return;
+            }
             action(ust);
 
             foreach (Ust child in ust.Children)


### PR DESCRIPTION
The function fails, for example, [here](https://github.com/PositiveTechnologies/PT.PM/blob/dev/Sources/PT.PM/WorkflowBase.cs#L254), if the result is null